### PR TITLE
Add workflow permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build-and-test:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci-cd.yml` file. The change adds permissions to write contents for the `build-and-test` job.