### PR TITLE
Update deploy pages action to use SHA instead of tag

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci-cd.yml` file. The change updates the version of the `actions/deploy-pages` action used for deployment to a specific commit hash.

* [`.github/workflows/ci-cd.yml`](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L61-R61): Updated `uses` to `actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` for the deployment step.