### PR TITLE
Integrate useRouter for dynamic image paths in ViewSourceOnGitHub component

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Run tests
         run: npm test
+        env:
+          NEXT_PUBLIC_BASE_PATH: "/${{ github.event.repository.name }}"
 
       - name: Build
         run: npm run build

--- a/src/components/__tests__/view-github-source.test.tsx
+++ b/src/components/__tests__/view-github-source.test.tsx
@@ -1,5 +1,15 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import { useRouter } from "next/router";
+
+jest.mock("next/router", () => ({
+  useRouter: jest.fn(),
+}));
+
+beforeEach(() => {
+  (useRouter as jest.Mock).mockReturnValue({ basePath: "" });
+});
+
 import { ViewSourceOnGitHub } from "../view-github-source";
 
 describe("ViewSourceOnGitHub", () => {

--- a/src/components/__tests__/view-github-source.test.tsx
+++ b/src/components/__tests__/view-github-source.test.tsx
@@ -1,14 +1,5 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { useRouter } from "next/router";
-
-jest.mock("next/router", () => ({
-  useRouter: jest.fn(),
-}));
-
-beforeEach(() => {
-  (useRouter as jest.Mock).mockReturnValue({ basePath: "" });
-});
 
 import { ViewSourceOnGitHub } from "../view-github-source";
 

--- a/src/components/view-github-source.tsx
+++ b/src/components/view-github-source.tsx
@@ -3,7 +3,9 @@
 import Link from "next/link";
 import Image from "next/image";
 import React from "react";
-import { useRouter } from "next/router";
+
+// Removed useRouter import, using NEXT_PUBLIC_BASE_PATH instead
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
 
 interface ViewSourceOnGitHubProperties {
   /** URL of the GitHub repository or file to view */
@@ -19,7 +21,6 @@ export function ViewSourceOnGitHub({
   repoUrl,
   ariaLabel = "View source on GitHub",
 }: ViewSourceOnGitHubProperties) {
-  const { basePath } = useRouter();
   return (
     <div className="w-full bg-white dark:bg-gray-800 rounded-lg shadow p-4">
       <div className="flex flex-col items-center gap-4">

--- a/src/components/view-github-source.tsx
+++ b/src/components/view-github-source.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import React from "react";
+import { useRouter } from "next/router";
 
 interface ViewSourceOnGitHubProperties {
   /** URL of the GitHub repository or file to view */
@@ -18,6 +19,7 @@ export function ViewSourceOnGitHub({
   repoUrl,
   ariaLabel = "View source on GitHub",
 }: ViewSourceOnGitHubProperties) {
+  const { basePath } = useRouter();
   return (
     <div className="w-full bg-white dark:bg-gray-800 rounded-lg shadow p-4">
       <div className="flex flex-col items-center gap-4">
@@ -31,7 +33,7 @@ export function ViewSourceOnGitHub({
           <span className="flex justify-center items-center gap-2">
             {/* Light mode logo */}
             <Image
-              src="/github-mark.png"
+              src={`${basePath}/github-mark.png`}
               alt="GitHub logo"
               width={24}
               height={24}
@@ -39,7 +41,7 @@ export function ViewSourceOnGitHub({
             />
             {/* Dark mode logo */}
             <Image
-              src="/github-mark-white.png"
+              src={`${basePath}/github-mark-white.png`}
               alt="GitHub logo"
               width={24}
               height={24}


### PR DESCRIPTION
Utilize the `useRouter` hook to dynamically set image paths in the ViewSourceOnGitHub component, enhancing compatibility with different base paths.