### PR TITLE
Reduce Dependabot noise with aggressive grouping and cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,13 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 3
+      semver-patch-days: 3
     groups:
-      actions-minor:
+      actions-all:
         update-types:
+          - major
           - minor
           - patch
 
@@ -17,14 +20,18 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 3
+      semver-patch-days: 3
     groups:
       npm-development:
         dependency-type: development
         update-types:
+          - major
           - minor
           - patch
       npm-production:
         dependency-type: production
         update-types:
+          - minor
           - patch


### PR DESCRIPTION
## Summary

Reduces Dependabot PR noise by grouping more aggressively and using semver-specific cooldowns.

### Changes to `dependabot.yml`
- **GitHub Actions**: group ALL updates (major+minor+patch) into a single PR instead of only minor+patch
- **npm dev deps**: group ALL updates including majors (typescript, eslint-plugin-unicorn, etc.)
- **npm prod deps**: add `minor` to group (was patch-only, so production minors came as singletons)
- **Cooldowns**: 14 days for majors (let early-adopter bugs surface), 3 days for minor/patch (faster safe updates)

### Why
Analysis of the last month showed 8 open Dependabot PRs — all major bumps. Every one had CI passing (`build-and-test: SUCCESS`) and was mergeable, but the automerge workflow skipped them because it only handles patch/minor. The grouping and cooldown changes reduce the number of PRs while the cooldown period de-risks majors.

### ⚠️ Manual step needed
The `dependabot-automerge.yml` workflow also needs updating to remove the semver-level `if` condition so majors get auto-approved+merged. I couldn't push that change because the OAuth token lacks the `workflow` scope. The change is:

Remove the `if` conditions from both the approve and merge steps so they apply to all Dependabot PRs unconditionally. CI (`build-and-test`) remains the real gate.

```diff
-      - name: Auto-approve patch and minor updates
-        if: >-
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr review --approve "$PR_URL"
+      - name: Auto-approve Dependabot PR
+        run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

-      - name: Enable auto-merge for patch and minor updates
-        if: >-
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr merge --auto --squash "$PR_URL"
+      - name: Enable auto-merge for Dependabot PR
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```