### PR TITLE
fix: use default-days cooldown for github-actions in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,7 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      semver-major-days: 14
-      semver-minor-days: 3
-      semver-patch-days: 3
+      default-days: 7
     groups:
       actions-all:
         update-types:


### PR DESCRIPTION
The `github-actions` package ecosystem does not support SemVer-granular cooldown options (`semver-major-days`, `semver-minor-days`, `semver-patch-days`). Having those keys in the config caused Dependabot's validation check to fail on every GitHub Actions PR it raised, blocking auto-merge.

Replace the three unsupported keys with `default-days: 7`, which is valid for all ecosystems and applies a 7-day cooldown to all GitHub Actions version updates regardless of semver level.

The `npm` ecosystem entry is unchanged, as it fully supports SemVer-granular cooldown options.