### PR TITLE
fix: resolve SVG aria-label mismatch causing \"Diagram not found\" on export

### DIFF
--- a/src/components/__tests__/file-operations.test.tsx
+++ b/src/components/__tests__/file-operations.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FileOperations } from "../file-operations";
 import { vi } from "vitest";
+import { RING_DIAGRAM_SVG_ARIA_LABEL } from "../../constants/diagram";
 
 // Mock the entire store module
 vi.mock("../../store/use-diagram-store", async () => {
@@ -182,8 +183,7 @@ describe("FileOperations", () => {
   });
 
   describe("SVG export", () => {
-    const DIAGRAM_ARIA_LABEL =
-      "Ring diagram showing points across different categories and rings";
+    const DIAGRAM_ARIA_LABEL = RING_DIAGRAM_SVG_ARIA_LABEL;
 
     it("renders an Export as SVG button", () => {
       render(<FileOperations />);

--- a/src/components/file-operations.tsx
+++ b/src/components/file-operations.tsx
@@ -2,9 +2,7 @@
 import { memo, useCallback, useState } from "react";
 import { useDiagramStore } from "../store/use-diagram-store";
 import { downloadSvg } from "../utils/svg-export";
-
-/** aria-label set on the ring diagram SVG element */
-const DIAGRAM_SVG_ARIA_LABEL = "Ring diagram showing points across different categories and rings";
+import { RING_DIAGRAM_SVG_ARIA_LABEL } from "../constants/diagram";
 
 export const FileOperations = memo(function FileOperations() {
   const saveDiagram = useDiagramStore((state) => state.saveDiagram);
@@ -46,7 +44,7 @@ export const FileOperations = memo(function FileOperations() {
     try {
       setError(undefined);
       const svgElement = document.querySelector<SVGSVGElement>(
-        `svg[aria-label="${DIAGRAM_SVG_ARIA_LABEL}"]`,
+        `svg[aria-label="${RING_DIAGRAM_SVG_ARIA_LABEL}"]`,
       );
       if (!svgElement) {
         setError("Diagram not found — please try again");

--- a/src/components/ring-diagram.tsx
+++ b/src/components/ring-diagram.tsx
@@ -7,6 +7,7 @@ import {
 } from "../store/use-diagram-store";
 import { Category, Preparedness, Relevance, Likelihood, Point } from "../types";
 import { RING_COLORS, PREPAREDNESS_COLORS } from "../constants/colors";
+import { RING_DIAGRAM_SVG_ARIA_LABEL } from "../constants/diagram";
 import { useResponsiveSize } from "../hooks/use-responsive-size";
 
 /** All category values in definition order. Computed once at module load. */
@@ -406,7 +407,7 @@ export const RingDiagram = () => {
           className="w-full h-auto"
           style={{ display: "block" }} // Ensure SVG is visible
           role="application"
-          aria-label="Interactive trend radar diagram. Use Tab to navigate trend points and Enter or Space to select."
+          aria-label={RING_DIAGRAM_SVG_ARIA_LABEL}
         />
       </div>
     </div>

--- a/src/constants/diagram.ts
+++ b/src/constants/diagram.ts
@@ -1,0 +1,3 @@
+/** aria-label applied to the ring diagram SVG element. Used for both accessibility and DOM querying. */
+export const RING_DIAGRAM_SVG_ARIA_LABEL =
+  "Interactive trend radar diagram. Use Tab to navigate trend points and Enter or Space to select.";


### PR DESCRIPTION
## Problem

Clicking "Export as SVG" always showed "Diagram not found — please try again".

The root cause was a stale constant in `file-operations.tsx` that didn't match the actual `aria-label` on the SVG in `ring-diagram.tsx`, so `document.querySelector('svg[aria-label="..."]')` always returned `null`.

## Fix

- Extracted a shared `RING_DIAGRAM_SVG_ARIA_LABEL` constant into `src/constants/diagram.ts`
- Updated both `ring-diagram.tsx` and `file-operations.tsx` to import and use it — keeping them in sync
- Updated tests to use the shared constant

All 348 tests pass. Lint is clean.